### PR TITLE
Add brief instruction screens to mini games

### DIFF
--- a/games/axe.py
+++ b/games/axe.py
@@ -67,6 +67,8 @@ def start():
     current_speed = BASE_SPEED
     score = 0
     start_thread()
+    show_instructions()
+    time.sleep(2)
 
 
 def start_thread():
@@ -270,4 +272,14 @@ def draw():
         fill_height = int(p_pos * (pow_bottom - pow_top))
         d.rectangle([pow_x0+1, pow_bottom-fill_height, pow_x1-1, pow_bottom-1], fill="gray")
         draw_axe(d, axe_x, axe_y)
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (SCREEN_W, SCREEN_H), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5, 5), "Axe Throw", font=fonts[1], fill="blue")
+    d.text((5, 30), "1=Lock Slider", font=fonts[0], fill="black")
+    d.text((5, 45), "2=Quit", font=fonts[0], fill="black")
+    d.text((5, 60), "Joy=Quit", font=fonts[0], fill="black")
     thread_safe_display(img)

--- a/games/doctor_mode.py
+++ b/games/doctor_mode.py
@@ -20,6 +20,8 @@ def init(display_func, fonts_tuple, quit_callback):
 
 def start():
     generate_pet_db()
+    show_instructions()
+    time.sleep(2)
     next_event()
 
 
@@ -175,5 +177,14 @@ def draw():
             y += 12
     else:
         d.text((25, 70), "(Press)", font=fonts[0], fill=(0, 255, 255))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5,5), "Doctor Mode", font=fonts[1], fill=(255,255,0))
+    d.text((5,30), "1-3=Select", font=fonts[0], fill=(0,255,255))
+    d.text((5,45), "Joy=Quit", font=fonts[0], fill=(255,0,0))
     thread_safe_display(img)
     

--- a/games/gta_1997.py
+++ b/games/gta_1997.py
@@ -57,6 +57,8 @@ def start():
     start_time = time.time()
     update_thread = threading.Thread(target=game_loop, daemon=True)
     update_thread.start()
+    show_instructions()
+    time.sleep(2)
     draw()
 
 def handle_input(pin):
@@ -181,4 +183,13 @@ def draw_game_over():
     msg = "Time Up" if lives > 0 else "Game Over"
     d.text((30, 50), msg, font=fonts[1], fill=(255, 0, 0))
     d.text((30, 70), f"Score: {score}", font=fonts[1], fill=(0, 255, 255))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5,5), "GTA 1997", font=fonts[1], fill=(255,255,0))
+    d.text((5,30), "Joy=Move", font=fonts[0], fill=(0,255,255))
+    d.text((5,45), "2/Press=Quit", font=fonts[0], fill=(255,0,0))
     thread_safe_display(img)

--- a/games/hack_in.py
+++ b/games/hack_in.py
@@ -29,6 +29,8 @@ def start():
     code_lines = []
     update_thread = threading.Thread(target=_loop, daemon=True)
     update_thread.start()
+    show_instructions()
+    time.sleep(2)
 
 
 def handle_input(pin):
@@ -78,4 +80,13 @@ def _draw():
         d.text((5, y), line, font=fonts[0], fill=(0, 255, 0))
         y += 12
     d.text((5, 115), "Press 3 to exit", font=fonts[0], fill=(255, 255, 0))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5,5), "Hack In", font=fonts[1], fill=(0,255,0))
+    d.text((5,30), "Watch the bar", font=fonts[0], fill=(0,255,255))
+    d.text((5,45), "3=Exit", font=fonts[0], fill=(255,0,0))
     thread_safe_display(img)

--- a/games/pico_wow.py
+++ b/games/pico_wow.py
@@ -60,6 +60,8 @@ def start():
     running = True
     update_thread = threading.Thread(target=_game_loop, daemon=True)
     update_thread.start()
+    show_instructions()
+    time.sleep(2)
     draw()
 
 
@@ -209,5 +211,15 @@ def draw_game_over():
     d = ImageDraw.Draw(img)
     d.text((20, 50), "Game Over", font=fonts[1], fill=(255, 0, 0))
     d.text((20, 70), f"Score: {score}", font=fonts[1], fill=(255, 255, 0))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (SCREEN_W, SCREEN_H), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5,5), "Pico WoW", font=fonts[1], fill=(255,255,0))
+    d.text((5,30), "Joy=Move", font=fonts[0], fill=(0,255,255))
+    d.text((5,45), "1/Press=Attack", font=fonts[0], fill=(0,255,255))
+    d.text((5,60), "2=Quit", font=fonts[0], fill=(255,0,0))
     thread_safe_display(img)
 

--- a/games/rps.py
+++ b/games/rps.py
@@ -17,6 +17,8 @@ def init(display_func, fonts_tuple, quit_callback):
 
 
 def start():
+    draw_instructions()
+    time.sleep(2)
     draw_prompt()
 
 
@@ -61,4 +63,13 @@ def draw_result(user, cpu, result):
     d.text((5, 5), f"You: {CHOICES[user]}", font=fonts[0], fill=(255, 255, 0))
     d.text((5, 20), f"CPU: {CHOICES[cpu]}", font=fonts[0], fill=(255, 255, 0))
     d.text((30, 60), result, font=fonts[1], fill=(255, 0, 0))
+    thread_safe_display(img)
+
+
+def draw_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5, 5), "Rock Paper Scissors", font=fonts[1], fill=(255, 255, 0))
+    d.text((5, 30), "1=Rock 2=Paper 3=Scissors", font=fonts[0], fill=(0, 255, 255))
+    d.text((5, 110), "Joy=Exit", font=fonts[0], fill=(255, 0, 0))
     thread_safe_display(img)

--- a/games/snake.py
+++ b/games/snake.py
@@ -35,6 +35,8 @@ def start():
     place_food()
     update_thread = threading.Thread(target=game_loop, daemon=True)
     update_thread.start()
+    show_instructions()
+    time.sleep(2)
     draw()
 
 
@@ -119,3 +121,12 @@ def stop():
     if update_thread:
         update_thread.join()
     exit_cb()
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5, 5), "Snake", font=fonts[1], fill=(0, 255, 0))
+    d.text((5, 30), "Use joystick to move", font=fonts[0], fill=(0, 255, 255))
+    d.text((5, 45), "Key2 to exit", font=fonts[0], fill=(255, 0, 0))
+    thread_safe_display(img)

--- a/games/space_invaders.py
+++ b/games/space_invaders.py
@@ -34,6 +34,8 @@ def start():
     move_dir = 1
     invaders = [(x * 12 + 16, y * 10 + 10) for y in range(INV_ROWS) for x in range(INV_COLS)]
     running = True
+    show_instructions()
+    time.sleep(2)
     draw()
     start_thread()
 
@@ -132,4 +134,13 @@ def draw_victory():
     img = Image.new("RGB", (SCREEN_W, SCREEN_H), "black")
     d = ImageDraw.Draw(img)
     d.text((30, 50), "You Win", font=fonts[1], fill=(0, 255, 0))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (SCREEN_W, SCREEN_H), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5, 5), "Space Invaders", font=fonts[1], fill=(255, 255, 0))
+    d.text((5, 30), "Joy=Move 1/Press=Fire", font=fonts[0], fill=(0, 255, 255))
+    d.text((5, 45), "2=Quit", font=fonts[0], fill=(255, 0, 0))
     thread_safe_display(img)

--- a/games/tetris.py
+++ b/games/tetris.py
@@ -67,6 +67,8 @@ def start():
     board = [[0 for _ in range(BOARD_W)] for _ in range(BOARD_H)]
     running = True
     spawn_piece()
+    show_instructions()
+    time.sleep(2)
     draw()
     start_thread()
 
@@ -216,4 +218,13 @@ def draw_game_over():
     img = Image.new("RGB", (128, 128), "black")
     d = ImageDraw.Draw(img)
     d.text((20, 50), "Game Over", font=fonts[1], fill=(255, 0, 0))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5, 5), "Tetris", font=fonts[1], fill=(255, 255, 0))
+    d.text((5, 30), "Joy=Move, 1=Rotate", font=fonts[0], fill=(0, 255, 255))
+    d.text((5, 45), "3=Drop, 2=Quit", font=fonts[0], fill=(0, 255, 255))
     thread_safe_display(img)

--- a/games/trivia.py
+++ b/games/trivia.py
@@ -359,6 +359,8 @@ def init(display_func, fonts_tuple, quit_callback):
 def start():
     global state
     state = "topics"
+    show_instructions()
+    time.sleep(2)
     draw_topics()
 
 
@@ -491,4 +493,13 @@ def draw_final():
     total = len(quiz_questions)
     d.text((25, 40), "Quiz Over", font=fonts[1], fill=(255, 255, 0))
     d.text((20, 70), f"Score: {score}/{total}", font=fonts[1], fill=(0, 255, 255))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5, 5), "Trivia", font=fonts[1], fill=(255, 255, 0))
+    d.text((5, 30), "1-3=Answer", font=fonts[0], fill=(0, 255, 255))
+    d.text((5, 45), "Joy=Quit", font=fonts[0], fill=(255, 0, 0))
     thread_safe_display(img)

--- a/games/two_player_trivia.py
+++ b/games/two_player_trivia.py
@@ -41,6 +41,8 @@ def start():
     question_idx = 0
     current_name = ""
     name_idx = 0
+    show_instructions()
+    time.sleep(2)
     draw_name_input()
 
 
@@ -236,5 +238,15 @@ def draw_final():
     else:
         winner = "Tie"
     d.text((5, 80), f"Winner: {winner}", font=fonts[1], fill=(0,255,0))
+    thread_safe_display(img)
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5,5), "2P Trivia", font=fonts[1], fill=(255,255,0))
+    d.text((5,30), "Left/Right=Buzz", font=fonts[0], fill=(0,255,255))
+    d.text((5,45), "1-3=Answer", font=fonts[0], fill=(0,255,255))
+    d.text((5,60), "Joy=Quit", font=fonts[0], fill=(255,0,0))
     thread_safe_display(img)
 

--- a/games/vet_adventure.py
+++ b/games/vet_adventure.py
@@ -236,6 +236,8 @@ def init(display_func, fonts_tuple, quit_callback):
 def start():
     global state
     state = "start"
+    show_instructions()
+    time.sleep(2)
     draw()
 
 
@@ -274,3 +276,12 @@ def draw():
     if state == "end":
         time.sleep(2)
         exit_cb()
+
+
+def show_instructions():
+    img = Image.new("RGB", (128, 128), "black")
+    d = ImageDraw.Draw(img)
+    d.text((5,5), "Vet Adventure", font=fonts[1], fill=(255,255,0))
+    d.text((5,30), "1-3=Choose", font=fonts[0], fill=(0,255,255))
+    d.text((5,45), "Joy=Quit", font=fonts[0], fill=(255,0,0))
+    thread_safe_display(img)


### PR DESCRIPTION
## Summary
- show instructions at start of each Python mini game

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cc7052118832fbb92193744639e2f