### PR TITLE
Update systemd service paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Mini OS uses BCM GPIO numbers. Connect the Waveshare 1.44" ST7735 display and bu
 ## Running as a `systemd` Service
 
 1. Copy `mini_os.service` to `/etc/systemd/system/` (or `~/.config/systemd/user/` for a user service).
-2. Adjust the paths in the unit file if you place the project somewhere other than `/opt/mini_os`.
+2. Adjust the paths in the unit file if you place the project somewhere other than `/home/<user>/mini_os`.
 3. Reload systemd and enable the service:
    ```bash
    sudo systemctl daemon-reload

--- a/mini_os.service
+++ b/mini_os.service
@@ -4,8 +4,11 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 /opt/mini_os/main.py
-WorkingDirectory=/opt/mini_os
+# Adjust the paths below if the project lives elsewhere.
+# This example assumes it resides under the service user's home
+# directory at ~/mini_os.
+ExecStart=/usr/bin/python3 %h/mini_os/main.py
+WorkingDirectory=%h/mini_os
 Restart=always
 User=pi
 Group=pi


### PR DESCRIPTION
## Summary
- update mini_os.service to use home directory paths
- clarify the service path in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ce73aa824832f8aa901271faea4f4