### PR TITLE
Update service path to use pico directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Mini OS uses BCM GPIO numbers. Connect the Waveshare 1.44" ST7735 display and bu
 ## Running as a `systemd` Service
 
 1. Copy `mini_os.service` to `/etc/systemd/system/` (or `~/.config/systemd/user/` for a user service).
-2. Adjust the paths in the unit file if you place the project somewhere other than `/home/<user>/mini_os`.
+2. Adjust the paths in the unit file if you place the project somewhere other than `/home/<user>/pico`.
 3. Reload systemd and enable the service:
    ```bash
    sudo systemctl daemon-reload

--- a/main.py
+++ b/main.py
@@ -951,7 +951,7 @@ menu_instance = None
 
 
 def run_git_pull():
-    """Update the mini_os directory using git pull."""
+    """Update the pico directory using git pull."""
     repo_dir = os.path.dirname(os.path.abspath(__file__))
     menu_instance.display_message_screen("Git Update", "Running git pull...", delay=1)
     try:

--- a/mini_os.service
+++ b/mini_os.service
@@ -6,9 +6,9 @@ After=network.target
 Type=simple
 # Adjust the paths below if the project lives elsewhere.
 # This example assumes it resides under the service user's home
-# directory at ~/mini_os.
-ExecStart=/usr/bin/python3 %h/mini_os/main.py
-WorkingDirectory=%h/mini_os
+# directory at ~/pico.
+ExecStart=/usr/bin/python3 %h/pico/main.py
+WorkingDirectory=%h/pico
 Restart=always
 User=pi
 Group=pi


### PR DESCRIPTION
## Summary
- use `/home/<user>/pico` path in service file
- document new path in README
- update git pull helper docstring

## Testing
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_684ce9224e30832f86190062809dbf46