### PR TITLE
Update Pico-8 path

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo raspi-config nonint do_spi 0
 
 Reboot after enabling SPI so the display can be accessed by the script.
 
-Download Pico‑8 for Raspberry Pi from <https://www.lexaloffle.com/pico‑8.php> and extract the binary somewhere accessible, for example `/opt/pico8`. The launcher expects the command `pico8` to be on your `PATH` or available via the `PICO8_PATH` environment variable.
+Download Pico‑8 for Raspberry Pi from <https://www.lexaloffle.com/pico‑8.php> and extract the binary somewhere accessible, for example `/home/<user>/pico-8`. The launcher expects the command `/home/<user>/pico-8/pico8` to be on your `PATH` or available via the `PICO8_PATH` environment variable.
 
 ### Running Pico‑8
 

--- a/main.py
+++ b/main.py
@@ -2998,7 +2998,9 @@ def start_pico8():
     """Launch the Pico-8 fantasy console if installed."""
     stop_scrolling()
     menu_instance.display_message_screen("PICO-8", "Launching...", delay=1)
-    cmd = os.environ.get("PICO8_PATH", "pico8")
+    # Default to pico8 installed under the user's home directory
+    default_cmd = os.path.expanduser("~/pico-8/pico8")
+    cmd = os.environ.get("PICO8_PATH", default_cmd)
     try:
         subprocess.run(
             [cmd, "-width", str(DISPLAY_WIDTH), "-height", str(DISPLAY_HEIGHT)],


### PR DESCRIPTION
## Summary
- note that Pico-8 is stored in `/home/<user>/pico-8`
- look for Pico-8 binary in `~/pico-8/pico8`

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684cee5a0398832f82d9b449685b29ed